### PR TITLE
Nomes em formato de lista + adição do yarn no gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+yarn.lock
 
 #IDE's
 .idea

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Project Stack Rate - PSR 
 ## Integrantes do Trabalho:
 - [Gustavo Zille](https://github.com/guszille)
-- [Marcos Junio](https://github.com/MarcosXavier93)
+- [Marcus Junio](https://github.com/MarcosXavier93)
 - [Pierre Vieira](https://github.com/PierreVieira)
 - [Samuel Santos](https://github.com/Samuel1s)
 - [Vinicius França](https://github.com/viniciusfdev)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Project Stack Rate - PSR 
-## Integrantes do Trabalho: Antônio Pierre, Gustavo Zille, Marcos Junio, Samuel Santos e Vinicius França
+## Integrantes do Trabalho:
+- [Gustavo Zille](https://github.com/guszille)
+- [Marcos Junio](https://github.com/MarcosXavier93)
+- [Pierre Vieira](https://github.com/PierreVieira)
+- [Samuel Santos](https://github.com/Samuel1s)
+- [Vinicius França](https://github.com/viniciusfdev)
 
 Site de rede social e ranqueamento de animes.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Project Stack Rate - PSR 
 ## Integrantes do Trabalho:
 - [Gustavo Zille](https://github.com/guszille)
-- [Marcus Junio](https://github.com/MarcosXavier93)
+- [Marcos Junio](https://github.com/MarcosXavier93)
 - [Pierre Vieira](https://github.com/PierreVieira)
 - [Samuel Santos](https://github.com/Samuel1s)
 - [Vinicius França](https://github.com/viniciusfdev)


### PR DESCRIPTION
## Qual o Problema Inicial?
Nomes não referenciando o github da pessoa.

## O que esse PR faz?
- Adiciona o nome das pessoas no readme.md em formato de lista referenciando o seu github.
- Adiciona o `yarn.lock` no .gitignore


**Issues relacionadas:**
Close https://github.com/MarcosXavier93/Project-Stack-Rate---PSR---ReactJs/issues/8
